### PR TITLE
Feature suggestion/add attribute before root vue render

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ const CustomElement = wrap(Vue, () => import(`MyComponent.vue`))
 
 window.customElements.define('my-element', CustomElement)
 ```
+### Usage with addtional attributes
+```js
+const vueAttributeBeforeRender = {
+        i18n:{ locale: 'de' },
+        foo:{ bar: 'test' },
+}; 
+
+const CustomElement = wrap(Vue, Component, vueAttributeBeforeRender)
+```
+This will add the attribute to the 
+```js  
+new Vue({ // attributes }) 
+```
 
 ## Interface Proxying Details
 


### PR DESCRIPTION
This PR introduces an option to pass arguments to main wrap function to add attribute to the new Vue object before render.
For use case of a plugin that needs to be rendered in the initial Vue instantiation.